### PR TITLE
Run CI on main branch instead of master

### DIFF
--- a/.github/workflows/cargo-doc.yaml
+++ b/.github/workflows/cargo-doc.yaml
@@ -3,7 +3,7 @@ name: API Docs
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - .github/workflows/cargo-doc.yml
       - Cargo.toml
@@ -40,7 +40,7 @@ jobs:
           args: --all-features
 
       - name: Push API documentation to GitHub Pages
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.IBC_RS_DOC_PRIVATE_KEY }}

--- a/.github/workflows/guide-templates.yaml
+++ b/.github/workflows/guide-templates.yaml
@@ -9,7 +9,7 @@ on:
       - guide/src/templates/**
 
   push:
-    branches: master
+    branches: main
     paths:
       - .github/workflows/guide-templates.yaml
       - crates/relayer-cli/**

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,7 @@ on:
       - crates/**
       - tools/**
   push:
-    branches: master
+    branches: main
     paths:
       - .github/workflows/integration.yaml
       - Cargo.toml

--- a/.github/workflows/multi-chains.yaml
+++ b/.github/workflows/multi-chains.yaml
@@ -18,7 +18,7 @@ on:
       - crates/**
       - tools/**
   push:
-    branches: master
+    branches: main
     paths:
       - .github/workflows/multi-chains.yaml
       - Cargo.toml
@@ -47,7 +47,7 @@ jobs:
   multi-chains-test:
     runs-on: ubuntu-20.04
     if: |
-      github.ref == 'refs/heads/master' || (
+      github.ref == 'refs/heads/main' || (
         (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize') &&
           contains(github.event.pull_request.labels.*.name, 'CI: multi-chains')
       ) || (

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -4,7 +4,7 @@ on:
     paths:
       - scripts/**
   push:
-    branches: master
+    branches: main
     paths:
       - scripts/**
 


### PR DESCRIPTION
The penumbra Hermes repo is using `main` as the primary branch, meaning the CI actions weren't running correctly.