### PR TITLE
add support for genesis restart to penumbra

### DIFF
--- a/crates/relayer-cli/src/commands/tx/client.rs
+++ b/crates/relayer-cli/src/commands/tx/client.rs
@@ -213,9 +213,8 @@ impl Runnable for TxUpdateClientCmd {
                     ChainConfig::CosmosSdk(chain_config) | ChainConfig::Astria(chain_config) => {
                         chain_config.genesis_restart = Some(restart_params)
                     }
-                    // TODO: Will probably need to support setting restart params on Penumbra somehow
-                    ChainConfig::Penumbra(_) => {
-                        todo!("penumbra doesn't support genesis restart params")
+                    ChainConfig::Penumbra(chain_config) => {
+                        chain_config.genesis_restart = Some(restart_params)
                     }
                 },
                 None => {

--- a/crates/relayer/src/chain/penumbra/chain.rs
+++ b/crates/relayer/src/chain/penumbra/chain.rs
@@ -559,13 +559,7 @@ impl ChainEndpoint for PenumbraChain {
             .block_on(IbcChannelQueryClient::connect(grpc_addr.clone()))
             .map_err(Error::grpc_transport)?;
 
-        let tendermint_light_client = TmLightClient::from_rpc_parameters(
-            config.id.clone(),
-            config.rpc_addr.clone(),
-            config.rpc_timeout,
-            node_info.id,
-            true,
-        )?;
+        let tendermint_light_client = TmLightClient::from_penumbra_config(&config, node_info.id)?;
 
         tracing::info!("ibc grpc query clients connected");
 

--- a/crates/relayer/src/chain/penumbra/config.rs
+++ b/crates/relayer/src/chain/penumbra/config.rs
@@ -6,8 +6,8 @@ use serde_derive::{Deserialize, Serialize};
 use tendermint_rpc::Url;
 
 use crate::config::{
-    compat_mode::CompatMode, default, types::TrustThreshold, EventSourceMode, PacketFilter,
-    RefreshRate,
+    compat_mode::CompatMode, default, types::TrustThreshold, EventSourceMode, GenesisRestart,
+    PacketFilter, RefreshRate,
 };
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -48,6 +48,11 @@ pub struct PenumbraConfig {
     pub query_packets_chunk_size: usize,
     #[serde(default = "default::max_block_time", with = "humantime_serde")]
     pub max_block_time: Duration,
+
+    // This field is only meant to be set via the `update client` command,
+    // for when we need to ugprade a client across a genesis restart and
+    // therefore need and archive node to fetch blocks from.
+    pub genesis_restart: Option<GenesisRestart>,
 
     /// A correction parameter that helps deal with clocks that are only approximately synchronized
     /// between the source and destination chains for a client.

--- a/crates/relayer/src/light_client/tendermint.rs
+++ b/crates/relayer/src/light_client/tendermint.rs
@@ -38,7 +38,10 @@ use super::{
     Verified,
 };
 use crate::{
-    chain::cosmos::{config::CosmosSdkConfig, CosmosSdkChain},
+    chain::{
+        cosmos::{config::CosmosSdkConfig, CosmosSdkChain},
+        penumbra::config::PenumbraConfig,
+    },
     client_state::AnyClientState,
     error::Error,
     misbehaviour::{AnyMisbehaviour, MisbehaviourEvidence},
@@ -285,6 +288,40 @@ impl LightClient {
             chain_id: chain_id.clone(),
             peer_id,
             io,
+            enable_verification,
+        })
+    }
+
+    pub fn from_penumbra_config(config: &PenumbraConfig, peer_id: PeerId) -> Result<Self, Error> {
+        let live_io = io_for_addr(&config.rpc_addr, peer_id, Some(config.rpc_timeout))?;
+
+        let io = match &config.genesis_restart {
+            None => AnyIo::Prod(live_io),
+            Some(genesis_restart) => {
+                let archive_io = io_for_addr(
+                    &genesis_restart.archive_addr,
+                    peer_id,
+                    Some(config.rpc_timeout),
+                )?;
+
+                AnyIo::RestartAware(RestartAwareIo::new(
+                    genesis_restart.restart_height,
+                    live_io,
+                    archive_io,
+                ))
+            }
+        };
+
+        // If the full node is configured as trusted then, in addition to headers not being verified,
+        // the verification traces will not be provided. This may cause failure in client
+        // updates after significant change in validator sets.
+        let enable_verification = false;
+
+        Ok(Self {
+            chain_id: config.id.clone(),
+            peer_id,
+            io,
+
             enable_verification,
         })
     }


### PR DESCRIPTION
This PR adds support for genesis restarting to penumbra, which is required for updating clients after and upgrade boundary.