### PR TITLE
Add default excluded_sequences value

### DIFF
--- a/crates/relayer/src/config.rs
+++ b/crates/relayer/src/config.rs
@@ -777,13 +777,12 @@ impl ChainConfig {
 
     pub fn excluded_sequences(&self, channel_id: &ChannelId) -> Cow<'_, [Sequence]> {
         match self {
-            Self::CosmosSdk(config) => config
+            Self::CosmosSdk(config) | Self::Astria(config) => config
                 .excluded_sequences
                 .get(channel_id)
                 .map(|seqs| Cow::Borrowed(seqs.as_slice()))
                 .unwrap_or_else(|| Cow::Owned(Vec::new())),
-            Self::Penumbra(_config) => todo!(),
-            Self::Astria(_config) => todo!(),
+            Self::Penumbra(_config) => Cow::Owned(Vec::new()),
         }
     }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #25

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
<!-- Apply relevant labels to indicate:
    - (WHY) The purpose or objective of this PR with "O" labels
    - (WHICH) The part of the system this PR relates to (use "E" for external or "I" for internal levels)
    - (HOW) If any administrative considerations should be taken into account (use "A" labels)
    This will help us prioritize and categorize your pull request more effectively 
-->
Fixes an issue with a `todo!()` for `excluded_sequences` introduced when merging upstream changes by setting the value to an empty `Vec` for Penumbra chains. If we ever do intend to introduce excluded sequences support, the Penumbra config struct will need to be modified to account for them.

______

