### PR TITLE
Audit all Penumbra-related todo items

### DIFF
--- a/crates/relayer-cli/src/commands/evidence.rs
+++ b/crates/relayer-cli/src/commands/evidence.rs
@@ -103,7 +103,8 @@ impl Runnable for EvidenceCmd {
             ChainConfig::CosmosSdk(ref _cfg) => {
                 CosmosSdkChain::bootstrap(chain_config, rt.clone()).unwrap()
             }
-            ChainConfig::Penumbra(_) => todo!(),
+            // TODO: Will need to rewrite this function to work with non-cosmosSDK chains
+            ChainConfig::Penumbra(_) => todo!("current implementation expects a cosmosSDK chain"),
         };
 
         let res = monitor_misbehaviours(

--- a/crates/relayer-cli/src/commands/keys/add.rs
+++ b/crates/relayer-cli/src/commands/keys/add.rs
@@ -235,7 +235,7 @@ pub fn add_key(
             keyring.add_key(key_name, key_pair.clone())?;
             key_pair.into()
         }
-        ChainConfig::Penumbra(_) => todo!(),
+        ChainConfig::Penumbra(_) => unimplemented!("no key storage support for penumbra"),
     };
 
     Ok(key_pair)
@@ -292,7 +292,7 @@ pub fn restore_key(
             keyring.add_key(key_name, key_pair.clone())?;
             key_pair.into()
         }
-        ChainConfig::Penumbra(_) => todo!(),
+        ChainConfig::Penumbra(_) => unimplemented!("no key storage support for penumbra"),
     };
 
     Ok(key_pair)

--- a/crates/relayer-cli/src/commands/keys/balance.rs
+++ b/crates/relayer-cli/src/commands/keys/balance.rs
@@ -78,7 +78,7 @@ fn get_balance(chain: impl ChainHandle, key_name: Option<String>, denom: Option<
                 match chain_config {
                     ChainConfig::CosmosSdk(chain_config) => chain_config.key_name,
                     ChainConfig::Astria(chain_config) => chain_config.key_name,
-                    ChainConfig::Penumbra(_) => todo!(),
+                    ChainConfig::Penumbra(_) => unimplemented!("no key support for penumbra"),
                 }
             });
 
@@ -102,7 +102,7 @@ fn get_balances(chain: impl ChainHandle, key_name: Option<String>) {
                 match chain_config {
                     ChainConfig::CosmosSdk(chain_config) => chain_config.key_name,
                     ChainConfig::Astria(chain_config) => chain_config.key_name,
-                    ChainConfig::Penumbra(_) => todo!(),
+                    ChainConfig::Penumbra(_) => unimplemented!("no key support for penumbra"),
                 }
             });
 

--- a/crates/relayer-cli/src/commands/keys/delete.rs
+++ b/crates/relayer-cli/src/commands/keys/delete.rs
@@ -129,7 +129,7 @@ pub fn delete_key(config: &ChainConfig, key_name: &str) -> eyre::Result<()> {
             )?;
             keyring.remove_key(key_name)?;
         }
-        ChainConfig::Penumbra(_) => todo!(),
+        ChainConfig::Penumbra(_) => unimplemented!("no key support for penumbra"),
     }
     Ok(())
 }
@@ -160,7 +160,7 @@ pub fn delete_all_keys(config: &ChainConfig) -> eyre::Result<()> {
                 keyring.remove_key(&key_name)?;
             }
         }
-        ChainConfig::Penumbra(_) => todo!(),
+        ChainConfig::Penumbra(_) => unimplemented!("no key support for penumbra"),
     }
     Ok(())
 }

--- a/crates/relayer-cli/src/commands/query/packet/commitment.rs
+++ b/crates/relayer-cli/src/commands/query/packet/commitment.rs
@@ -19,6 +19,7 @@ use crate::{
     prelude::*,
 };
 
+#[allow(dead_code)]
 #[derive(Serialize, Debug)]
 struct PacketSeqs {
     height: Height,

--- a/crates/relayer-cli/src/commands/tx/client.rs
+++ b/crates/relayer-cli/src/commands/tx/client.rs
@@ -213,7 +213,10 @@ impl Runnable for TxUpdateClientCmd {
                     ChainConfig::CosmosSdk(chain_config) | ChainConfig::Astria(chain_config) => {
                         chain_config.genesis_restart = Some(restart_params)
                     }
-                    ChainConfig::Penumbra(_) => todo!(),
+                    // TODO: Will probably need to support setting restart params on Penumbra somehow
+                    ChainConfig::Penumbra(_) => {
+                        todo!("penumbra doesn't support genesis restart params")
+                    }
                 },
                 None => {
                     Output::error(format!(

--- a/tools/integration-test/src/bin/test_setup_with_binary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_binary_channel.rs
@@ -48,7 +48,7 @@ impl TestOverrides for Test {
                     // with external relayer commands.
                     chain_config.key_store_type = Store::Test;
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
     }

--- a/tools/integration-test/src/bin/test_setup_with_fee_enabled_binary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_fee_enabled_binary_channel.rs
@@ -49,7 +49,7 @@ impl TestOverrides for Test {
                     // with external relayer commands.
                     chain_config.key_store_type = Store::Test;
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
     }

--- a/tools/integration-test/src/bin/test_setup_with_ternary_channel.rs
+++ b/tools/integration-test/src/bin/test_setup_with_ternary_channel.rs
@@ -48,7 +48,7 @@ impl TestOverrides for Test {
                     // with external relayer commands.
                     chain_config.key_store_type = Store::Test;
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
     }

--- a/tools/integration-test/src/mbt/transfer.rs
+++ b/tools/integration-test/src/mbt/transfer.rs
@@ -164,7 +164,8 @@ impl TestOverrides for IbcTransferMBT {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.trusting_period = Some(CLIENT_EXPIRY);
                 }
-                ChainConfig::Penumbra(_) | ChainConfig::Astria(_) => todo!(),
+                ChainConfig::Penumbra(_chain_config) => {}
+                ChainConfig::Astria(_) => todo!(),
             }
         }
     }

--- a/tools/integration-test/src/tests/async_icq/simple_query.rs
+++ b/tools/integration-test/src/tests/async_icq/simple_query.rs
@@ -143,7 +143,7 @@ fn assert_eventual_async_icq_success<ChainA: ChainHandle, ChainB: ChainHandle>(
 ) -> Result<(), Error> {
     let rpc_addr = match relayer.config.chains.first().unwrap() {
         ChainConfig::CosmosSdk(c) => c.rpc_addr.clone(),
-        ChainConfig::Penumbra(_c) => todo!(),
+        ChainConfig::Penumbra(c) => c.rpc_addr.clone(),
         ChainConfig::Astria(_c) => todo!(),
     };
 

--- a/tools/integration-test/src/tests/clear_packet.rs
+++ b/tools/integration-test/src/tests/clear_packet.rs
@@ -325,7 +325,7 @@ impl TestOverrides for ClearPacketOverrideTest {
             match chain_config {
                 // Use a small clear interval in the chain configurations to override the global high interval
                 ChainConfig::CosmosSdk(chain_config) => chain_config.clear_interval = Some(10),
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(chain_config) => chain_config.clear_interval = Some(10),
                 ChainConfig::Astria(_) => todo!(),
             }
         }

--- a/tools/integration-test/src/tests/client_expiration.rs
+++ b/tools/integration-test/src/tests/client_expiration.rs
@@ -123,7 +123,7 @@ impl TestOverrides for ExpirationTestOverrides {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.trusting_period = Some(CLIENT_EXPIRY);
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
                 ChainConfig::Astria(_) => todo!(),
             }
         }

--- a/tools/integration-test/src/tests/client_settings.rs
+++ b/tools/integration-test/src/tests/client_settings.rs
@@ -37,7 +37,11 @@ impl TestOverrides for ClientDefaultsTest {
                 chain_config_a.trusting_period = Some(Duration::from_secs(120_000));
                 chain_config_a.trust_threshold = TrustThreshold::new(13, 23).unwrap();
             }
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(chain_config_a) => {
+                chain_config_a.clock_drift = Duration::from_secs(3);
+                chain_config_a.max_block_time = Duration::from_secs(5);
+                chain_config_a.trust_threshold = TrustThreshold::new(13, 23).unwrap();
+            }
             ChainConfig::Astria(_) => todo!(),
         }
 
@@ -48,7 +52,11 @@ impl TestOverrides for ClientDefaultsTest {
                 chain_config_b.trusting_period = Some(Duration::from_secs(340_000));
                 chain_config_b.trust_threshold = TrustThreshold::TWO_THIRDS;
             }
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(chain_config_b) => {
+                chain_config_b.clock_drift = Duration::from_secs(6);
+                chain_config_b.max_block_time = Duration::from_secs(15);
+                chain_config_b.trust_threshold = TrustThreshold::TWO_THIRDS;
+            }
             ChainConfig::Astria(_) => todo!(),
         }
     }

--- a/tools/integration-test/src/tests/dynamic_gas_fee.rs
+++ b/tools/integration-test/src/tests/dynamic_gas_fee.rs
@@ -52,7 +52,9 @@ impl TestOverrides for DynamicGasTest {
                     GasPrice::new(0.1, chain_config_a.gas_price.denom.clone());
                 chain_config_a.dynamic_gas_price = DynamicGasPrice::unsafe_new(false, 1.1, 0.6);
             }
-            ChainConfig::Penumbra(_chain_config_a) => todo!(),
+            ChainConfig::Penumbra(_chain_config_a) => {
+                todo!("need to implement gas support for penumbra chains")
+            }
             ChainConfig::Astria(_chain_config_a) => todo!(),
         }
 
@@ -63,7 +65,9 @@ impl TestOverrides for DynamicGasTest {
                 chain_config_b.dynamic_gas_price =
                     DynamicGasPrice::unsafe_new(self.dynamic_gas_enabled, 1.1, 0.6);
             }
-            ChainConfig::Penumbra(_chain_config_b) => todo!(),
+            ChainConfig::Penumbra(_chain_config_a) => {
+                todo!("need to implement gas support for penumbra chains")
+            }
             ChainConfig::Astria(_chain_config_b) => todo!(),
         }
     }

--- a/tools/integration-test/src/tests/fee/filter_fees.rs
+++ b/tools/integration-test/src/tests/fee/filter_fees.rs
@@ -33,7 +33,9 @@ impl TestOverrides for FilterIncentivizedFeesRelayerTest {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.packet_filter = packet_filter.clone();
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(chain_config) => {
+                    chain_config.packet_filter = packet_filter.clone();
+                }
                 ChainConfig::Astria(_) => todo!(),
             }
         }
@@ -204,7 +206,9 @@ impl TestOverrides for FilterByChannelIncentivizedFeesRelayerTest {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.packet_filter = packet_filter.clone();
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(chain_config) => {
+                    chain_config.packet_filter = packet_filter.clone();
+                }
                 ChainConfig::Astria(_) => todo!(),
             }
         }

--- a/tools/integration-test/src/tests/fee_grant.rs
+++ b/tools/integration-test/src/tests/fee_grant.rs
@@ -81,7 +81,9 @@ impl BinaryChannelTest for FeeGrantTest {
             .ok_or_else(|| eyre!("chain configuration is empty"))?
         {
             ChainConfig::CosmosSdk(chain_config) => chain_config.gas_price.denom.clone(),
-            ChainConfig::Penumbra(_chain_config) => todo!(),
+            ChainConfig::Penumbra(_chain_config) => {
+                todo!("need to implement gas support for penumbra chains")
+            }
             ChainConfig::Astria(_chain_config) => todo!(),
         };
 
@@ -108,7 +110,9 @@ impl BinaryChannelTest for FeeGrantTest {
                         ChainConfig::CosmosSdk(c) => {
                             c.fee_granter = Some("user2".to_owned());
                         }
-                        ChainConfig::Penumbra(_c) => todo!(),
+                        ChainConfig::Penumbra(_chain_config) => {
+                            todo!("need to implement gas support for penumbra chains")
+                        }
                         ChainConfig::Astria(_c) => todo!(),
                     }
                 }
@@ -228,7 +232,9 @@ impl BinaryChannelTest for NoFeeGrantTest {
             .ok_or_else(|| eyre!("chain configuration is empty"))?
         {
             ChainConfig::CosmosSdk(chain_config) => chain_config.gas_price.denom.clone(),
-            ChainConfig::Penumbra(_chain_config) => todo!(),
+            ChainConfig::Penumbra(_chain_config) => {
+                todo!("need to implement gas support for penumbra chains")
+            }
             ChainConfig::Astria(_chain_config) => todo!(),
         };
 

--- a/tools/integration-test/src/tests/ica.rs
+++ b/tools/integration-test/src/tests/ica.rs
@@ -69,7 +69,9 @@ impl TestOverrides for IcaFilterTestAllow {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.packet_filter = self.packet_filter.clone();
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(chain_config) => {
+                    chain_config.packet_filter = self.packet_filter.clone();
+                }
                 ChainConfig::Astria(_) => todo!(),
             }
         }
@@ -202,7 +204,13 @@ impl TestOverrides for IcaFilterTestDeny {
                             FilterPattern::Wildcard("*".parse().unwrap()),
                         )]));
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(chain_config) => {
+                    chain_config.packet_filter.channel_policy =
+                        ChannelPolicy::Deny(ChannelFilters::new(vec![(
+                            FilterPattern::Wildcard("ica*".parse().unwrap()),
+                            FilterPattern::Wildcard("*".parse().unwrap()),
+                        )]));
+                }
                 ChainConfig::Astria(_) => todo!(),
             }
         }

--- a/tools/integration-test/src/tests/memo.rs
+++ b/tools/integration-test/src/tests/memo.rs
@@ -38,7 +38,7 @@ impl TestOverrides for MemoTest {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.memo_prefix = self.memo.clone();
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
                 ChainConfig::Astria(_) => todo!(),
             }
         }
@@ -105,7 +105,7 @@ impl TestOverrides for MemoOverwriteTest {
                     chain_config.memo_overwrite = Some(Memo::new(OVERWRITE_MEMO).unwrap())
                 }
                 ChainConfig::Astria(_) => todo!(),
-                ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
     }

--- a/tools/integration-test/src/tests/ordered_channel_clear.rs
+++ b/tools/integration-test/src/tests/ordered_channel_clear.rs
@@ -56,7 +56,8 @@ impl TestOverrides for OrderedChannelClearTest {
                 ChainConfig::CosmosSdk(chain_config) => {
                     chain_config.sequential_batch_tx = self.sequential_batch_tx;
                 }
-                ChainConfig::Astria(_) | ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Astria(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
 
@@ -65,7 +66,8 @@ impl TestOverrides for OrderedChannelClearTest {
             ChainConfig::CosmosSdk(chain_config) => {
                 chain_config.sequential_batch_tx = self.sequential_batch_tx;
             }
-            ChainConfig::Astria(_) | ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Astria(_) => todo!(),
+            ChainConfig::Penumbra(_) => {}
         }
     }
 
@@ -202,7 +204,8 @@ impl TestOverrides for OrderedChannelClearEqualCLITest {
                     chain_config.sequential_batch_tx = true;
                     chain_config.max_msg_num = MaxMsgNum::new(3).unwrap();
                 }
-                ChainConfig::Astria(_) | ChainConfig::Penumbra(_) => todo!(),
+                ChainConfig::Astria(_) => todo!(),
+                ChainConfig::Penumbra(_) => {}
             }
         }
 
@@ -212,7 +215,8 @@ impl TestOverrides for OrderedChannelClearEqualCLITest {
                 chain_config.sequential_batch_tx = true;
                 chain_config.max_msg_num = MaxMsgNum::new(3).unwrap();
             }
-            ChainConfig::Astria(_) | ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Astria(_) => todo!(),
+            ChainConfig::Penumbra(_) => {}
         }
     }
 

--- a/tools/integration-test/src/tests/python.rs
+++ b/tools/integration-test/src/tests/python.rs
@@ -18,7 +18,8 @@ impl TestOverrides for PythonTest {
                     // with external relayer commands.
                     chain_config.key_store_type = Store::Test;
                 }
-                ChainConfig::Penumbra(_) => todo!(),
+                // No key support for Penumbra
+                ChainConfig::Penumbra(_) => {}
                 ChainConfig::Astria(_) => todo!(),
             }
         }

--- a/tools/integration-test/src/tests/sequence_filter.rs
+++ b/tools/integration-test/src/tests/sequence_filter.rs
@@ -55,7 +55,7 @@ impl TestOverrides for FilterClearOnStartTest {
                 chain_config.excluded_sequences = excluded_sequences;
             }
             ChainConfig::Astria(_) => todo!(),
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(_) => {}
         }
         config.mode.channels.enabled = true;
 
@@ -94,7 +94,7 @@ impl TestOverrides for FilterClearIntervalTest {
                 chain_config.excluded_sequences = excluded_sequences;
             }
             ChainConfig::Astria(_) => todo!(),
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(_) => {}
         }
         config.mode.channels.enabled = true;
 
@@ -255,7 +255,7 @@ impl TestOverrides for StandardRelayingNoFilterTest {
                 chain_config.excluded_sequences = excluded_sequences;
             }
             ChainConfig::Astria(_) => todo!(),
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(_) => {}
         }
         config.mode.packets.clear_on_start = true;
         config.mode.packets.clear_interval = 0;

--- a/tools/integration-test/src/tests/tendermint/sequential.rs
+++ b/tools/integration-test/src/tests/tendermint/sequential.rs
@@ -37,7 +37,7 @@ impl TestOverrides for SequentialCommitTest {
                 chain_config_a.max_msg_num = MaxMsgNum::new(MESSAGES_PER_BATCH).unwrap();
                 chain_config_a.sequential_batch_tx = true;
             }
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(_) => todo!("sequential batching unsupported in penumbra"),
         };
 
         match &mut config.chains[1] {
@@ -45,7 +45,7 @@ impl TestOverrides for SequentialCommitTest {
                 chain_config_b.max_msg_num = MaxMsgNum::new(MESSAGES_PER_BATCH).unwrap();
                 chain_config_b.sequential_batch_tx = false;
             }
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::Penumbra(_) => todo!("sequential batching unsupported in penumbra"),
         };
     }
 

--- a/tools/test-framework/src/util/interchain_security.rs
+++ b/tools/test-framework/src/util/interchain_security.rs
@@ -33,8 +33,7 @@ pub fn update_relayer_config_for_consumer_chain(config: &mut Config) {
                 chain_config.ccv_consumer_chain = true;
                 chain_config.trusting_period = Some(Duration::from_secs(99));
             }
-            ChainConfig::CosmosSdk(_) | ChainConfig::Astria(_) => {}
-            ChainConfig::Penumbra(_) => todo!(),
+            ChainConfig::CosmosSdk(_) | ChainConfig::Astria(_) | ChainConfig::Penumbra(_) => {}
         }
     }
 }


### PR DESCRIPTION
We audited all existing `todo` items, replacing them with `unimplemented` when appropriate and adding more context to the outstanding `todo` items.

We still have some outstanding questions, for example:

- Should we implement a trusting period in the Penumbra Hermes configs?
- The evidence command is unimplemented and expects a CosmosSDK chain; is this command important?
- Do we need to support genesis reset parameters?
- Do we need to implement IBC channel/client state queries in Penumbra?
- Do we need to implement cross-chain queries?

Closes #19 