### PR TITLE
chore: bump penumbra tag to v0.75.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1225,8 +1237,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1270,12 +1282,12 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.71.0",
+ "cnidarium 0.75.0",
  "hex",
  "tendermint",
 ]
@@ -1650,8 +1662,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1664,8 +1676,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1674,7 +1686,7 @@ dependencies = [
  "decaf377-rdsa",
  "frost-core",
  "frost-rerandomized",
- "penumbra-proto 0.71.0",
+ "penumbra-proto 0.75.0",
  "rand_core",
 ]
 
@@ -1694,8 +1706,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2775,14 +2787,14 @@ dependencies = [
  "num-rational",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
  "penumbra-custody",
  "penumbra-fee",
  "penumbra-ibc 0.69.1",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
  "penumbra-proto 0.69.1",
- "penumbra-proto 0.71.0",
+ "penumbra-proto 0.75.0",
  "penumbra-transaction",
  "penumbra-view",
  "penumbra-wallet",
@@ -4283,6 +4295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,8 +4402,8 @@ checksum = "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
 
 [[package]]
 name = "penumbra-app"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4390,8 +4413,8 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4404,28 +4427,28 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
  "penumbra-dex",
  "penumbra-distributions",
  "penumbra-fee",
  "penumbra-funding",
- "penumbra-genesis",
  "penumbra-governance",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
+ "penumbra-tct 0.75.0",
  "penumbra-tendermint-proxy",
  "penumbra-tower-trace",
  "penumbra-transaction",
- "penumbra-txhash 0.71.0",
+ "penumbra-txhash 0.75.0",
  "prost 0.12.4",
  "rand_chacha",
  "regex",
@@ -4491,8 +4514,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4505,7 +4528,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
+ "decaf377-fmd 0.75.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4514,8 +4537,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4528,29 +4551,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-auction"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+dependencies = [
+ "anyhow",
+ "ark-ff",
+ "ark-groth16",
+ "ark-r1cs-std",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "bech32 0.8.1",
+ "bitvec",
+ "blake2b_simd 1.0.2",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
+ "decaf377 0.5.0",
+ "decaf377-rdsa",
+ "futures",
+ "hex",
+ "metrics",
+ "once_cell",
+ "pbjson-types",
+ "penumbra-asset 0.75.0",
+ "penumbra-dex",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proof-params",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
+ "penumbra-shielded-pool",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
+ "prost 0.12.4",
+ "prost-types",
+ "rand_chacha",
+ "rand_core",
+ "regex",
+ "serde",
+ "serde_unit_struct",
+ "serde_with",
+ "sha2 0.10.8",
+ "tap",
+ "tendermint",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "penumbra-community-pool"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "futures",
  "hex",
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
- "penumbra-txhash 0.71.0",
+ "penumbra-txhash 0.75.0",
  "prost 0.12.4",
  "serde",
  "sha2 0.10.8",
@@ -4561,16 +4637,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377-rdsa",
  "futures",
  "im",
@@ -4579,13 +4655,13 @@ dependencies = [
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.71.0",
+ "penumbra-ibc 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
+ "penumbra-tct 0.75.0",
  "rand",
  "rand_core",
  "serde",
@@ -4598,10 +4674,11 @@ dependencies = [
 
 [[package]]
 name = "penumbra-custody"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
+ "argon2",
  "ark-ff",
  "ark-serialize",
  "base64 0.21.7",
@@ -4610,17 +4687,17 @@ dependencies = [
  "chacha20poly1305",
  "decaf377 0.5.0",
  "decaf377-frost",
- "decaf377-ka 0.71.0",
+ "decaf377-ka 0.75.0",
  "decaf377-rdsa",
  "ed25519-consensus",
  "futures",
  "hex",
  "penumbra-governance",
- "penumbra-keys 0.71.0",
- "penumbra-proto 0.71.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-proto 0.75.0",
  "penumbra-stake",
  "penumbra-transaction",
- "penumbra-txhash 0.71.0",
+ "penumbra-txhash 0.75.0",
  "prost 0.12.4",
  "rand_core",
  "serde",
@@ -4633,8 +4710,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4648,11 +4725,11 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
- "decaf377-ka 0.71.0",
+ "decaf377-fmd 0.75.0",
+ "decaf377-ka 0.75.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4661,16 +4738,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
  "penumbra-fee",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "poseidon377",
  "prost 0.12.4",
  "rand_core",
@@ -4689,17 +4766,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
- "penumbra-asset 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "serde",
  "tendermint",
  "tracing",
@@ -4707,22 +4784,22 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "metrics",
- "penumbra-asset 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
  "rand",
  "rand_core",
  "serde",
@@ -4733,20 +4810,20 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "futures",
  "metrics",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
  "penumbra-community-pool",
  "penumbra-distributions",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
  "serde",
@@ -4755,29 +4832,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "penumbra-genesis"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
-dependencies = [
- "anyhow",
- "penumbra-community-pool",
- "penumbra-dex",
- "penumbra-distributions",
- "penumbra-fee",
- "penumbra-funding",
- "penumbra-governance",
- "penumbra-ibc 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
- "penumbra-shielded-pool",
- "penumbra-stake",
- "serde",
-]
-
-[[package]]
 name = "penumbra-governance"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4791,8 +4848,8 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4801,27 +4858,29 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-distributions",
  "penumbra-fee",
  "penumbra-funding",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "rand",
  "rand_chacha",
  "rand_core",
  "regex",
  "serde",
+ "serde_json",
  "tap",
  "tendermint",
  "thiserror",
@@ -4866,15 +4925,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.71.0",
+ "cnidarium 0.75.0",
  "hex",
  "ibc-proto 0.41.0",
  "ibc-types 0.12.0",
@@ -4883,11 +4942,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "prost 0.12.4",
  "serde",
  "serde_json",
@@ -4945,8 +5004,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "aes",
  "anyhow",
@@ -4962,8 +5021,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
- "decaf377-ka 0.71.0",
+ "decaf377-fmd 0.75.0",
+ "decaf377-ka 0.75.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4974,9 +5033,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2 0.12.2",
- "penumbra-asset 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-tct 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-tct 0.75.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5025,8 +5084,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5041,7 +5100,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
+ "decaf377-fmd 0.75.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -5049,7 +5108,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-proto 0.71.0",
+ "penumbra-proto 0.75.0",
  "rand",
  "rand_core",
  "regex",
@@ -5061,8 +5120,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5118,15 +5177,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.8.1",
  "bytes",
- "cnidarium 0.71.0",
- "decaf377-fmd 0.71.0",
+ "cnidarium 0.75.0",
+ "decaf377-fmd 0.75.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -5183,8 +5242,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5195,17 +5254,17 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "hex",
  "im",
  "metrics",
  "once_cell",
- "penumbra-keys 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-tct 0.71.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-tct 0.75.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5217,8 +5276,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5232,26 +5291,27 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
- "decaf377-ka 0.71.0",
+ "decaf377-fmd 0.75.0",
+ "decaf377-ka 0.75.0",
  "decaf377-rdsa",
+ "futures",
  "hex",
  "ibc-types 0.12.0",
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.71.0",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
- "penumbra-tct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "poseidon377",
  "prost 0.12.4",
  "rand",
@@ -5267,8 +5327,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5282,8 +5342,8 @@ dependencies = [
  "base64 0.21.7",
  "bech32 0.8.1",
  "bitvec",
- "cnidarium 0.71.0",
- "cnidarium-component 0.71.0",
+ "cnidarium 0.75.0",
+ "cnidarium-component 0.75.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -5291,17 +5351,17 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
  "penumbra-community-pool",
  "penumbra-distributions",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -5346,8 +5406,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5364,7 +5424,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-proto 0.71.0",
+ "penumbra-proto 0.75.0",
  "poseidon377",
  "rand",
  "serde",
@@ -5374,8 +5434,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5384,7 +5444,7 @@ dependencies = [
  "http",
  "metrics",
  "pbjson-types",
- "penumbra-proto 0.71.0",
+ "penumbra-proto 0.75.0",
  "penumbra-transaction",
  "pin-project",
  "pin-project-lite",
@@ -5406,8 +5466,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "futures",
  "hex",
@@ -5428,8 +5488,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5440,8 +5500,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.71.0",
- "decaf377-ka 0.71.0",
+ "decaf377-fmd 0.75.0",
+ "decaf377-ka 0.75.0",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -5450,21 +5510,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
  "penumbra-proof-params",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
- "penumbra-txhash 0.71.0",
+ "penumbra-tct 0.75.0",
+ "penumbra-txhash 0.75.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5492,21 +5553,21 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "hex",
- "penumbra-proto 0.71.0",
- "penumbra-tct 0.71.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-tct 0.75.0",
  "serde",
 ]
 
 [[package]]
 name = "penumbra-view"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5524,8 +5585,10 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
+ "pbjson-types",
  "penumbra-app",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
+ "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
  "penumbra-dex",
@@ -5533,14 +5596,14 @@ dependencies = [
  "penumbra-fee",
  "penumbra-funding",
  "penumbra-governance",
- "penumbra-ibc 0.71.0",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-ibc 0.75.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
+ "penumbra-tct 0.75.0",
  "penumbra-transaction",
  "prost 0.12.4",
  "r2d2",
@@ -5550,6 +5613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "tap",
  "tendermint",
  "tokio",
  "tokio-stream",
@@ -5561,8 +5625,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wallet"
-version = "0.71.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.71.0#b0c8cc44734401e36d3496f17a2ea99a0b1944d1"
+version = "0.75.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5571,17 +5635,17 @@ dependencies = [
  "decaf377 0.5.0",
  "hex",
  "penumbra-app",
- "penumbra-asset 0.71.0",
+ "penumbra-asset 0.75.0",
  "penumbra-custody",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-keys 0.71.0",
- "penumbra-num 0.71.0",
- "penumbra-proto 0.71.0",
- "penumbra-sct 0.71.0",
+ "penumbra-keys 0.75.0",
+ "penumbra-num 0.75.0",
+ "penumbra-proto 0.75.0",
+ "penumbra-sct 0.75.0",
  "penumbra-stake",
- "penumbra-tct 0.71.0",
+ "penumbra-tct 0.75.0",
  "penumbra-transaction",
  "penumbra-view",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,18 +42,18 @@ astria-sequencer-client = { git = "https://github.com/astriaorg/astria", rev = "
 ] }
 
 # Penumbra dependencies.
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0", features = [
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0", features = [
     "box-grpc",
     "rpc",
 ] }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
-penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.71.0" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
 # Penumbra dependencies, specifically for Astria support. Renamespaced, to avoid conflicts with Penumbra support.
 penumbra-ibc-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-ibc", tag = "v0.69.1" }
 penumbra-proto-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-proto", tag = "v0.69.1", features = [

--- a/config-penumbra-osmosis.toml
+++ b/config-penumbra-osmosis.toml
@@ -26,7 +26,7 @@ host = '127.0.0.1'
 port = 3001
 
 [[chains]]
-id = 'penumbra-testnet-deimos-5'
+id = 'penumbra-testnet-deimos-8'
 type = 'Penumbra'
 stub_key_name = 'fake'
 rpc_addr = 'https://rpc.testnet.penumbra.zone'


### PR DESCRIPTION
Updates the dependencies for the most recent testnet: https://github.com/penumbra-zone/penumbra/releases/tag/v0.75.0