### PR TITLE
chore: bump penumbra deps 0.75.0 -> 0.76.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,11 +1237,12 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.7",
  "borsh 1.4.0",
  "futures",
  "hex",
@@ -1282,12 +1283,12 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.75.0",
+ "cnidarium 0.76.0",
  "hex",
  "tendermint",
 ]
@@ -1662,8 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1676,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1686,7 +1687,7 @@ dependencies = [
  "decaf377-rdsa",
  "frost-core",
  "frost-rerandomized",
- "penumbra-proto 0.75.0",
+ "penumbra-proto 0.76.0",
  "rand_core",
 ]
 
@@ -1706,8 +1707,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2787,14 +2788,14 @@ dependencies = [
  "num-rational",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-custody",
  "penumbra-fee",
  "penumbra-ibc 0.69.1",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
  "penumbra-proto 0.69.1",
- "penumbra-proto 0.75.0",
+ "penumbra-proto 0.76.0",
  "penumbra-transaction",
  "penumbra-view",
  "penumbra-wallet",
@@ -4402,8 +4403,8 @@ checksum = "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
 
 [[package]]
 name = "penumbra-app"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4413,8 +4414,8 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4427,7 +4428,7 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
@@ -4436,19 +4437,20 @@ dependencies = [
  "penumbra-fee",
  "penumbra-funding",
  "penumbra-governance",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
+ "penumbra-tct 0.76.0",
  "penumbra-tendermint-proxy",
+ "penumbra-test-subscriber",
  "penumbra-tower-trace",
  "penumbra-transaction",
- "penumbra-txhash 0.75.0",
+ "penumbra-txhash 0.76.0",
  "prost 0.12.4",
  "rand_chacha",
  "regex",
@@ -4514,8 +4516,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4528,7 +4530,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
+ "decaf377-fmd 0.76.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4537,8 +4539,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4552,8 +4554,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4568,8 +4570,8 @@ dependencies = [
  "bech32 0.8.1",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4577,23 +4579,22 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-dex",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "prost 0.12.4",
  "prost-types",
  "rand_chacha",
  "rand_core",
  "regex",
  "serde",
- "serde_unit_struct",
  "serde_with",
  "sha2 0.10.8",
  "tap",
@@ -4605,28 +4606,28 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "futures",
  "hex",
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
- "penumbra-txhash 0.75.0",
+ "penumbra-txhash 0.76.0",
  "prost 0.12.4",
  "serde",
  "sha2 0.10.8",
@@ -4637,31 +4638,30 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377-rdsa",
  "futures",
  "im",
  "metrics",
- "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.75.0",
+ "penumbra-ibc 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
+ "penumbra-tct 0.76.0",
  "rand",
  "rand_core",
  "serde",
@@ -4674,8 +4674,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-custody"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4687,17 +4687,17 @@ dependencies = [
  "chacha20poly1305",
  "decaf377 0.5.0",
  "decaf377-frost",
- "decaf377-ka 0.75.0",
+ "decaf377-ka 0.76.0",
  "decaf377-rdsa",
  "ed25519-consensus",
  "futures",
  "hex",
  "penumbra-governance",
- "penumbra-keys 0.75.0",
- "penumbra-proto 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-proto 0.76.0",
  "penumbra-stake",
  "penumbra-transaction",
- "penumbra-txhash 0.75.0",
+ "penumbra-txhash 0.76.0",
  "prost 0.12.4",
  "rand_core",
  "serde",
@@ -4710,8 +4710,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4725,11 +4725,11 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
- "decaf377-ka 0.75.0",
+ "decaf377-fmd 0.76.0",
+ "decaf377-ka 0.76.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4738,16 +4738,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-fee",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "poseidon377",
  "prost 0.12.4",
  "rand_core",
@@ -4760,23 +4760,24 @@ dependencies = [
  "tendermint-light-client-verifier",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
- "penumbra-asset 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "serde",
  "tendermint",
  "tracing",
@@ -4784,22 +4785,22 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "metrics",
- "penumbra-asset 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
  "rand",
  "rand_core",
  "serde",
@@ -4810,20 +4811,20 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "futures",
  "metrics",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-community-pool",
  "penumbra-distributions",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
  "serde",
@@ -4833,8 +4834,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4848,8 +4849,8 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4858,23 +4859,18 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
- "penumbra-auction",
- "penumbra-community-pool",
- "penumbra-dex",
+ "penumbra-asset 0.76.0",
  "penumbra-distributions",
- "penumbra-fee",
- "penumbra-funding",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -4925,15 +4921,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.75.0",
+ "cnidarium 0.76.0",
+ "futures",
  "hex",
  "ibc-proto 0.41.0",
  "ibc-types 0.12.0",
@@ -4942,17 +4939,18 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "prost 0.12.4",
  "serde",
  "serde_json",
  "sha2 0.10.8",
  "tendermint",
  "tendermint-light-client-verifier",
+ "time",
  "tonic",
  "tower",
  "tracing",
@@ -5004,8 +5002,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "aes",
  "anyhow",
@@ -5021,8 +5019,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
- "decaf377-ka 0.75.0",
+ "decaf377-fmd 0.76.0",
+ "decaf377-ka 0.76.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -5033,9 +5031,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2 0.12.2",
- "penumbra-asset 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-tct 0.75.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-tct 0.76.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5084,8 +5082,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5100,7 +5098,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
+ "decaf377-fmd 0.76.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -5108,7 +5106,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-proto 0.75.0",
+ "penumbra-proto 0.76.0",
  "rand",
  "rand_core",
  "regex",
@@ -5120,8 +5118,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5177,15 +5175,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.8.1",
  "bytes",
- "cnidarium 0.75.0",
- "decaf377-fmd 0.75.0",
+ "cnidarium 0.76.0",
+ "decaf377-fmd 0.76.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -5242,8 +5240,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5254,17 +5252,17 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "hex",
  "im",
  "metrics",
  "once_cell",
- "penumbra-keys 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-tct 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-tct 0.76.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5276,8 +5274,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5286,36 +5284,39 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
- "decaf377-ka 0.75.0",
+ "decaf377-fmd 0.76.0",
+ "decaf377-ka 0.76.0",
  "decaf377-rdsa",
  "futures",
  "hex",
+ "ibc-proto 0.41.0",
  "ibc-types 0.12.0",
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.75.0",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-asset 0.76.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "poseidon377",
  "prost 0.12.4",
  "rand",
  "rand_core",
+ "regex",
  "serde",
  "serde_json",
  "tap",
@@ -5327,8 +5328,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5342,8 +5343,8 @@ dependencies = [
  "base64 0.21.7",
  "bech32 0.8.1",
  "bitvec",
- "cnidarium 0.75.0",
- "cnidarium-component 0.75.0",
+ "cnidarium 0.76.0",
+ "cnidarium-component 0.76.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -5351,17 +5352,16 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.75.0",
- "penumbra-community-pool",
+ "penumbra-asset 0.76.0",
  "penumbra-distributions",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -5406,8 +5406,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5424,7 +5424,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-proto 0.75.0",
+ "penumbra-proto 0.76.0",
  "poseidon377",
  "rand",
  "serde",
@@ -5434,8 +5434,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5444,7 +5444,7 @@ dependencies = [
  "http",
  "metrics",
  "pbjson-types",
- "penumbra-proto 0.75.0",
+ "penumbra-proto 0.76.0",
  "penumbra-transaction",
  "pin-project",
  "pin-project-lite",
@@ -5465,9 +5465,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "penumbra-test-subscriber"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
 name = "penumbra-tower-trace"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "futures",
  "hex",
@@ -5488,8 +5497,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5500,8 +5509,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.75.0",
- "decaf377-ka 0.75.0",
+ "decaf377-fmd 0.76.0",
+ "decaf377-ka 0.76.0",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -5510,22 +5519,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
  "penumbra-proof-params",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
- "penumbra-txhash 0.75.0",
+ "penumbra-tct 0.76.0",
+ "penumbra-txhash 0.76.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5553,21 +5562,21 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "hex",
- "penumbra-proto 0.75.0",
- "penumbra-tct 0.75.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-tct 0.76.0",
  "serde",
 ]
 
 [[package]]
 name = "penumbra-view"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5587,7 +5596,7 @@ dependencies = [
  "parking_lot",
  "pbjson-types",
  "penumbra-app",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
@@ -5596,14 +5605,14 @@ dependencies = [
  "penumbra-fee",
  "penumbra-funding",
  "penumbra-governance",
- "penumbra-ibc 0.75.0",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-ibc 0.76.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
+ "penumbra-tct 0.76.0",
  "penumbra-transaction",
  "prost 0.12.4",
  "r2d2",
@@ -5625,8 +5634,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wallet"
-version = "0.75.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.75.0#2e122d3c098bb2e1e0df811357aa8d11b5a9bcdb"
+version = "0.76.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5635,17 +5644,17 @@ dependencies = [
  "decaf377 0.5.0",
  "hex",
  "penumbra-app",
- "penumbra-asset 0.75.0",
+ "penumbra-asset 0.76.0",
  "penumbra-custody",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-keys 0.75.0",
- "penumbra-num 0.75.0",
- "penumbra-proto 0.75.0",
- "penumbra-sct 0.75.0",
+ "penumbra-keys 0.76.0",
+ "penumbra-num 0.76.0",
+ "penumbra-proto 0.76.0",
+ "penumbra-sct 0.76.0",
  "penumbra-stake",
- "penumbra-tct 0.75.0",
+ "penumbra-tct 0.76.0",
  "penumbra-transaction",
  "penumbra-view",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,18 +42,18 @@ astria-sequencer-client = { git = "https://github.com/astriaorg/astria", rev = "
 ] }
 
 # Penumbra dependencies.
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0", features = [
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0", features = [
     "box-grpc",
     "rpc",
 ] }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
-penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.75.0" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
 # Penumbra dependencies, specifically for Astria support. Renamespaced, to avoid conflicts with Penumbra support.
 penumbra-ibc-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-ibc", tag = "v0.69.1" }
 penumbra-proto-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-proto", tag = "v0.69.1", features = [


### PR DESCRIPTION
We made this change ad-hoc during deployment of Testnet 76. Submitting it via PR to the repo to make sure we don't regress builds. Refs https://github.com/penumbra-zone/penumbra/issues/4402