### PR TITLE
chore: bump penumbra deps to v0.77.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,8 +1237,8 @@ dependencies = [
 
 [[package]]
 name = "cnidarium"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1283,12 +1283,12 @@ dependencies = [
 
 [[package]]
 name = "cnidarium-component"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.76.0",
+ "cnidarium 0.77.0",
  "hex",
  "tendermint",
 ]
@@ -1663,8 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1677,8 +1677,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-frost"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -1687,7 +1687,7 @@ dependencies = [
  "decaf377-rdsa",
  "frost-core",
  "frost-rerandomized",
- "penumbra-proto 0.76.0",
+ "penumbra-proto 0.77.0",
  "rand_core",
 ]
 
@@ -1707,8 +1707,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-ka"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "ark-ff",
  "decaf377 0.5.0",
@@ -2788,14 +2788,14 @@ dependencies = [
  "num-rational",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-custody",
  "penumbra-fee",
  "penumbra-ibc 0.69.1",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
  "penumbra-proto 0.69.1",
- "penumbra-proto 0.76.0",
+ "penumbra-proto 0.77.0",
  "penumbra-transaction",
  "penumbra-view",
  "penumbra-wallet",
@@ -4403,8 +4403,8 @@ checksum = "36bae92c60fa2398ce4678b98b2c4b5a7c61099961ca1fa305aec04a9ad28922"
 
 [[package]]
 name = "penumbra-app"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4414,8 +4414,8 @@ dependencies = [
  "bincode",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4428,7 +4428,7 @@ dependencies = [
  "metrics",
  "once_cell",
  "parking_lot",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
@@ -4437,20 +4437,20 @@ dependencies = [
  "penumbra-fee",
  "penumbra-funding",
  "penumbra-governance",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
+ "penumbra-tct 0.77.0",
  "penumbra-tendermint-proxy",
  "penumbra-test-subscriber",
  "penumbra-tower-trace",
  "penumbra-transaction",
- "penumbra-txhash 0.76.0",
+ "penumbra-txhash 0.77.0",
  "prost 0.12.4",
  "rand_chacha",
  "regex",
@@ -4516,8 +4516,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4530,7 +4530,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
+ "decaf377-fmd 0.77.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -4539,8 +4539,8 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -4554,8 +4554,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-auction"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4570,8 +4570,8 @@ dependencies = [
  "bech32 0.8.1",
  "bitvec",
  "blake2b_simd 1.0.2",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4579,16 +4579,16 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-dex",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "prost 0.12.4",
  "prost-types",
  "rand_chacha",
@@ -4606,28 +4606,28 @@ dependencies = [
 
 [[package]]
 name = "penumbra-community-pool"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "futures",
  "hex",
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
- "penumbra-txhash 0.76.0",
+ "penumbra-txhash 0.77.0",
  "prost 0.12.4",
  "serde",
  "sha2 0.10.8",
@@ -4638,16 +4638,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-compact-block"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377-rdsa",
  "futures",
  "im",
@@ -4655,13 +4655,13 @@ dependencies = [
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.76.0",
+ "penumbra-ibc 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
+ "penumbra-tct 0.77.0",
  "rand",
  "rand_core",
  "serde",
@@ -4674,8 +4674,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-custody"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4687,17 +4687,17 @@ dependencies = [
  "chacha20poly1305",
  "decaf377 0.5.0",
  "decaf377-frost",
- "decaf377-ka 0.76.0",
+ "decaf377-ka 0.77.0",
  "decaf377-rdsa",
  "ed25519-consensus",
  "futures",
  "hex",
  "penumbra-governance",
- "penumbra-keys 0.76.0",
- "penumbra-proto 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-proto 0.77.0",
  "penumbra-stake",
  "penumbra-transaction",
- "penumbra-txhash 0.76.0",
+ "penumbra-txhash 0.77.0",
  "prost 0.12.4",
  "rand_core",
  "serde",
@@ -4710,8 +4710,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-dex"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4725,11 +4725,11 @@ dependencies = [
  "base64 0.21.7",
  "bincode",
  "blake2b_simd 1.0.2",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
- "decaf377-ka 0.76.0",
+ "decaf377-fmd 0.77.0",
+ "decaf377-ka 0.77.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -4738,16 +4738,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbjson-types",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-fee",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "poseidon377",
  "prost 0.12.4",
  "rand_core",
@@ -4767,17 +4767,17 @@ dependencies = [
 
 [[package]]
 name = "penumbra-distributions"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
- "penumbra-asset 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "serde",
  "tendermint",
  "tracing",
@@ -4785,22 +4785,22 @@ dependencies = [
 
 [[package]]
 name = "penumbra-fee"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "metrics",
- "penumbra-asset 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
  "rand",
  "rand_core",
  "serde",
@@ -4811,20 +4811,20 @@ dependencies = [
 
 [[package]]
 name = "penumbra-funding"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "async-trait",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "futures",
  "metrics",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-community-pool",
  "penumbra-distributions",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
  "serde",
@@ -4834,8 +4834,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-governance"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -4849,8 +4849,8 @@ dependencies = [
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -4859,18 +4859,18 @@ dependencies = [
  "metrics",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-distributions",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "rand",
  "rand_chacha",
  "rand_core",
@@ -4921,15 +4921,15 @@ dependencies = [
 
 [[package]]
 name = "penumbra-ibc"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
  "async-trait",
  "base64 0.21.7",
  "blake2b_simd 1.0.2",
- "cnidarium 0.76.0",
+ "cnidarium 0.77.0",
  "futures",
  "hex",
  "ibc-proto 0.41.0",
@@ -4939,11 +4939,11 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "prost 0.12.4",
  "serde",
  "serde_json",
@@ -5002,8 +5002,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-keys"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "aes",
  "anyhow",
@@ -5019,8 +5019,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
- "decaf377-ka 0.76.0",
+ "decaf377-fmd 0.77.0",
+ "decaf377-ka 0.77.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -5031,9 +5031,9 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbkdf2 0.12.2",
- "penumbra-asset 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-tct 0.76.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-tct 0.77.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5082,8 +5082,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5098,7 +5098,7 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
+ "decaf377-fmd 0.77.0",
  "decaf377-rdsa",
  "derivative",
  "ethnum",
@@ -5106,7 +5106,7 @@ dependencies = [
  "ibig",
  "num-bigint",
  "once_cell",
- "penumbra-proto 0.76.0",
+ "penumbra-proto 0.77.0",
  "rand",
  "rand_core",
  "regex",
@@ -5118,8 +5118,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proof-params"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -5175,15 +5175,16 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "async-trait",
  "bech32 0.8.1",
  "bytes",
- "cnidarium 0.76.0",
- "decaf377-fmd 0.76.0",
+ "chrono",
+ "cnidarium 0.77.0",
+ "decaf377-fmd 0.77.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -5199,6 +5200,9 @@ dependencies = [
  "serde_json",
  "subtle-encoding",
  "tendermint",
+ "tendermint-proto",
+ "tendermint-rpc",
+ "thiserror",
  "tonic",
  "tower",
  "tracing",
@@ -5240,8 +5244,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-sct"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5252,17 +5256,17 @@ dependencies = [
  "bincode",
  "blake2b_simd 1.0.2",
  "bytes",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "hex",
  "im",
  "metrics",
  "once_cell",
- "penumbra-keys 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-tct 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-tct 0.77.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5274,8 +5278,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-shielded-pool"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5290,11 +5294,11 @@ dependencies = [
  "blake2b_simd 1.0.2",
  "bytes",
  "chacha20poly1305",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
- "decaf377-ka 0.76.0",
+ "decaf377-fmd 0.77.0",
+ "decaf377-ka 0.77.0",
  "decaf377-rdsa",
  "futures",
  "hex",
@@ -5303,15 +5307,15 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.76.0",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-asset 0.77.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "poseidon377",
  "prost 0.12.4",
  "rand",
@@ -5328,8 +5332,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-stake"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5343,8 +5347,8 @@ dependencies = [
  "base64 0.21.7",
  "bech32 0.8.1",
  "bitvec",
- "cnidarium 0.76.0",
- "cnidarium-component 0.76.0",
+ "cnidarium 0.77.0",
+ "cnidarium-component 0.77.0",
  "decaf377 0.5.0",
  "decaf377-rdsa",
  "futures",
@@ -5352,16 +5356,16 @@ dependencies = [
  "im",
  "metrics",
  "once_cell",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-distributions",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "rand_chacha",
  "rand_core",
  "regex",
@@ -5406,8 +5410,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tct"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "ark-ed-on-bls12-377",
  "ark-ff",
@@ -5424,7 +5428,7 @@ dependencies = [
  "im",
  "once_cell",
  "parking_lot",
- "penumbra-proto 0.76.0",
+ "penumbra-proto 0.77.0",
  "poseidon377",
  "rand",
  "serde",
@@ -5434,8 +5438,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tendermint-proxy"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5444,11 +5448,12 @@ dependencies = [
  "http",
  "metrics",
  "pbjson-types",
- "penumbra-proto 0.76.0",
+ "penumbra-proto 0.77.0",
  "penumbra-transaction",
  "pin-project",
  "pin-project-lite",
  "sha2 0.10.8",
+ "tap",
  "tendermint",
  "tendermint-config",
  "tendermint-light-client-verifier",
@@ -5466,8 +5471,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-test-subscriber"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
@@ -5475,8 +5480,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-tower-trace"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "futures",
  "hex",
@@ -5497,8 +5502,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-transaction"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -5509,8 +5514,8 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "decaf377 0.5.0",
- "decaf377-fmd 0.76.0",
- "decaf377-ka 0.76.0",
+ "decaf377-fmd 0.77.0",
+ "decaf377-ka 0.77.0",
  "decaf377-rdsa",
  "derivative",
  "hex",
@@ -5519,22 +5524,22 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "pbjson-types",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
  "penumbra-proof-params",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
- "penumbra-txhash 0.76.0",
+ "penumbra-tct 0.77.0",
+ "penumbra-txhash 0.77.0",
  "poseidon377",
  "rand",
  "rand_core",
@@ -5562,21 +5567,21 @@ dependencies = [
 
 [[package]]
 name = "penumbra-txhash"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "blake2b_simd 1.0.2",
  "hex",
- "penumbra-proto 0.76.0",
- "penumbra-tct 0.76.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-tct 0.77.0",
  "serde",
 ]
 
 [[package]]
 name = "penumbra-view"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5596,7 +5601,7 @@ dependencies = [
  "parking_lot",
  "pbjson-types",
  "penumbra-app",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-auction",
  "penumbra-community-pool",
  "penumbra-compact-block",
@@ -5605,14 +5610,14 @@ dependencies = [
  "penumbra-fee",
  "penumbra-funding",
  "penumbra-governance",
- "penumbra-ibc 0.76.0",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-ibc 0.77.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-shielded-pool",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
+ "penumbra-tct 0.77.0",
  "penumbra-transaction",
  "prost 0.12.4",
  "r2d2",
@@ -5634,8 +5639,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-wallet"
-version = "0.76.0"
-source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.76.0#75c5c9449c5d05cb668233e2875aaaf92aa74f4b"
+version = "0.77.0"
+source = "git+https://github.com/penumbra-zone/penumbra?tag=v0.77.0#00a859b99697fe7e5a7459d86210c2760cd27682"
 dependencies = [
  "anyhow",
  "ark-std",
@@ -5644,17 +5649,17 @@ dependencies = [
  "decaf377 0.5.0",
  "hex",
  "penumbra-app",
- "penumbra-asset 0.76.0",
+ "penumbra-asset 0.77.0",
  "penumbra-custody",
  "penumbra-dex",
  "penumbra-fee",
  "penumbra-governance",
- "penumbra-keys 0.76.0",
- "penumbra-num 0.76.0",
- "penumbra-proto 0.76.0",
- "penumbra-sct 0.76.0",
+ "penumbra-keys 0.77.0",
+ "penumbra-num 0.77.0",
+ "penumbra-proto 0.77.0",
+ "penumbra-sct 0.77.0",
  "penumbra-stake",
- "penumbra-tct 0.76.0",
+ "penumbra-tct 0.77.0",
  "penumbra-transaction",
  "penumbra-view",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,18 +42,18 @@ astria-sequencer-client = { git = "https://github.com/astriaorg/astria", rev = "
 ] }
 
 # Penumbra dependencies.
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0", features = [
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-fee = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-ibc = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-keys = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0", features = [
     "box-grpc",
     "rpc",
 ] }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
-penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.76.0" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
+penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "v0.77.0" }
 # Penumbra dependencies, specifically for Astria support. Renamespaced, to avoid conflicts with Penumbra support.
 penumbra-ibc-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-ibc", tag = "v0.69.1" }
 penumbra-proto-astria = { git = "https://github.com/penumbra-zone/penumbra", package = "penumbra-proto", tag = "v0.69.1", features = [


### PR DESCRIPTION
Refs https://github.com/penumbra-zone/penumbra/issues/4497

Also includes a lock file update, which https://github.com/penumbra-zone/hermes/pull/34 lacked. Thanks for pointing that out, @zbuc.