### PR TITLE
penumbra: filter out non-ibc events from event processing

### DIFF
--- a/crates/relayer/src/chain/penumbra/chain.rs
+++ b/crates/relayer/src/chain/penumbra/chain.rs
@@ -190,7 +190,13 @@ impl PenumbraChain {
             .tx_result
             .events
             .iter()
-            .map(|ev| IbcEventWithHeight::new(ibc_event_try_from_abci_event(ev).unwrap(), height))
+            .filter_map(|ev| {
+                if let Ok(ibc_event) = ibc_event_try_from_abci_event(ev) {
+                    Some(IbcEventWithHeight::new(ibc_event, height))
+                } else {
+                    None
+                }
+            })
             .collect();
 
         Ok(events)


### PR DESCRIPTION
Previously, we unconditionally attempted to convert all events to ibc events. This worked because there were never txs that had other events (e.g., fees). Now that the testnet requires fees, we need to filter out non-ibc events, this PR does that.