### PR TITLE
chain(penumbra): use gRPC for proof queries

### DIFF
--- a/crates/relayer/src/chain/penumbra/chain.rs
+++ b/crates/relayer/src/chain/penumbra/chain.rs
@@ -1,9 +1,11 @@
 use anyhow::Context;
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use futures::{FutureExt, StreamExt, TryStreamExt};
 use http::Uri;
 use ibc_proto::ics23;
 
+use ibc_proto::ibc::core::channel::v1::QueryChannelRequest as RawQueryChannelRequest;
+use ibc_proto::ibc::core::channel::v1::QueryNextSequenceReceiveRequest as RawQueryNextSequenceReceiveRequest;
 use ibc_proto::ibc::core::channel::v1::QueryPacketAcknowledgementRequest as RawQueryPacketAcknowledgementRequest;
 use ibc_proto::ibc::core::channel::v1::QueryPacketCommitmentRequest as RawQueryPacketCommitmentRequest;
 use ibc_proto::ibc::core::channel::v1::QueryPacketReceiptRequest as RawQueryPacketReceiptRequest;
@@ -12,8 +14,6 @@ use ibc_proto::ibc::core::client::v1::QueryConsensusStateRequest as RawQueryCons
 use ibc_proto::ibc::core::connection::v1::QueryConnectionRequest as RawQueryConnectionRequest;
 
 use ibc_relayer_types::core::ics23_commitment::commitment::CommitmentProofBytes;
-use ibc_relayer_types::core::ics24_host::path::{ChannelEndsPath, SeqRecvsPath};
-use ibc_relayer_types::core::ics24_host::Path;
 use once_cell::sync::Lazy;
 use penumbra_proto::core::app::v1::AppParametersRequest;
 use penumbra_proto::core::component::ibc::v1::IbcRelay as ProtoIbcRelay;
@@ -23,11 +23,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use tendermint_proto::Protobuf;
 use tracing::info;
 
 use crate::chain::client::ClientSettings;
-use crate::chain::cosmos::query::{abci_query, fetch_version_specs, QueryResponse};
+use crate::chain::cosmos::query::fetch_version_specs;
 use crate::chain::endpoint::ChainStatus;
 use crate::chain::requests::*;
 use crate::chain::tracking::TrackedMsgs;

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -177,22 +177,13 @@ pub struct QueryConsensusStateRequest {
 
 impl From<QueryConsensusStateRequest> for RawQueryConsensusStateRequest {
     fn from(request: QueryConsensusStateRequest) -> Self {
-        // We extract the revision number and revision height, unless we are
-        // querying at the latest height.
-        if let QueryHeight::Specific(height) = request.query_height {
-            Self {
-                client_id: request.client_id.to_string(),
-                revision_number: height.revision_number(),
-                revision_height: height.revision_height(),
-                latest_height: false,
-            }
-        } else {
-            Self {
-                client_id: request.client_id.to_string(),
-                revision_number: 0,
-                revision_height: 0,
-                latest_height: true,
-            }
+        Self {
+            client_id: request.client_id.to_string(),
+            // TODO(erwan): not a fan of having two different height representations in the same
+            // struct. We should probably refactor this.
+            revision_number: request.consensus_height.revision_number(),
+            revision_height: request.consensus_height.revision_height(),
+            latest_height: matches!(request.query_height, QueryHeight::Latest),
         }
     }
 }

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -14,6 +14,7 @@ use ibc_proto::{
             QueryUnreceivedPacketsRequest as RawQueryUnreceivedPacketsRequest,
         },
         client::v1::{
+            QueryClientStateRequest as RawQueryClientStateRequest,
             QueryClientStatesRequest as RawQueryClientStatesRequest,
             QueryConsensusStateHeightsRequest as RawQueryConsensusStateHeightsRequest,
             QueryConsensusStatesRequest as RawQueryConsensusStatesRequest,
@@ -142,6 +143,14 @@ impl From<PageRequest> for RawPageRequest {
 pub struct QueryClientStateRequest {
     pub client_id: ClientId,
     pub height: QueryHeight,
+}
+
+impl From<QueryClientStateRequest> for RawQueryClientStateRequest {
+    fn from(request: QueryClientStateRequest) -> Self {
+        Self {
+            client_id: request.client_id.to_string(),
+        }
+    }
 }
 
 /// gRPC query to fetch all client states associated with the chain.

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -8,8 +8,11 @@ use ibc_proto::{
             QueryChannelsRequest as RawQueryChannelsRequest,
             QueryConnectionChannelsRequest as RawQueryConnectionChannelsRequest,
             QueryNextSequenceReceiveRequest as RawQueryNextSequenceReceiveRequest,
+            QueryPacketAcknowledgementRequest as RawQueryPacketAcknowledgementRequest,
             QueryPacketAcknowledgementsRequest as RawQueryPacketAcknowledgementsRequest,
+            QueryPacketCommitmentRequest as RawQueryPacketCommitmentRequest,
             QueryPacketCommitmentsRequest as RawQueryPacketCommitmentsRequest,
+            QueryPacketReceiptRequest as RawQueryPacketReceiptRequest,
             QueryUnreceivedAcksRequest as RawQueryUnreceivedAcksRequest,
             QueryUnreceivedPacketsRequest as RawQueryUnreceivedPacketsRequest,
         },
@@ -22,6 +25,7 @@ use ibc_proto::{
         },
         connection::v1::{
             QueryClientConnectionsRequest as RawQueryClientConnectionsRequest,
+            QueryConnectionRequest as RawQueryConnectionRequest,
             QueryConnectionsRequest as RawQueryConnectionsRequest,
         },
     },
@@ -264,6 +268,14 @@ pub struct QueryConnectionRequest {
     pub height: QueryHeight,
 }
 
+impl From<QueryConnectionRequest> for RawQueryConnectionRequest {
+    fn from(request: QueryConnectionRequest) -> Self {
+        Self {
+            connection_id: request.connection_id.to_string(),
+        }
+    }
+}
+
 /// gRPC query to fetch all channels associated with the specified connection.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryConnectionChannelsRequest {
@@ -325,6 +337,16 @@ pub struct QueryPacketCommitmentRequest {
     pub height: QueryHeight,
 }
 
+impl From<QueryPacketCommitmentRequest> for RawQueryPacketCommitmentRequest {
+    fn from(request: QueryPacketCommitmentRequest) -> Self {
+        RawQueryPacketCommitmentRequest {
+            port_id: request.port_id.to_string(),
+            channel_id: request.channel_id.to_string(),
+            sequence: request.sequence.into(),
+        }
+    }
+}
+
 /// gRPC query to fetch the packet commitment hashes associated with the specified channel.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryPacketCommitmentsRequest {
@@ -349,6 +371,16 @@ pub struct QueryPacketReceiptRequest {
     pub channel_id: ChannelId,
     pub sequence: Sequence,
     pub height: QueryHeight,
+}
+
+impl From<QueryPacketReceiptRequest> for RawQueryPacketReceiptRequest {
+    fn from(request: QueryPacketReceiptRequest) -> Self {
+        Self {
+            port_id: request.port_id.to_string(),
+            channel_id: request.channel_id.to_string(),
+            sequence: request.sequence.as_u64(),
+        }
+    }
 }
 
 /// gRPC query to fetch all unreceived packet sequences associated with the specified channel.
@@ -379,6 +411,16 @@ pub struct QueryPacketAcknowledgementRequest {
     pub channel_id: ChannelId,
     pub sequence: Sequence,
     pub height: QueryHeight,
+}
+
+impl From<QueryPacketAcknowledgementRequest> for RawQueryPacketAcknowledgementRequest {
+    fn from(request: QueryPacketAcknowledgementRequest) -> Self {
+        RawQueryPacketAcknowledgementRequest {
+            port_id: request.port_id.to_string(),
+            channel_id: request.channel_id.to_string(),
+            sequence: request.sequence.as_u64(),
+        }
+    }
 }
 
 /// gRPC query to fetch all packet acknowledgements associated with the specified channel.

--- a/crates/relayer/src/chain/requests.rs
+++ b/crates/relayer/src/chain/requests.rs
@@ -5,6 +5,7 @@ use ibc_proto::{
     ibc::core::{
         channel::v1::{
             QueryChannelClientStateRequest as RawQueryChannelClientStateRequest,
+            QueryChannelRequest as RawQueryChannelRequest,
             QueryChannelsRequest as RawQueryChannelsRequest,
             QueryConnectionChannelsRequest as RawQueryConnectionChannelsRequest,
             QueryNextSequenceReceiveRequest as RawQueryNextSequenceReceiveRequest,
@@ -311,6 +312,15 @@ pub struct QueryChannelRequest {
     pub port_id: PortId,
     pub channel_id: ChannelId,
     pub height: QueryHeight,
+}
+
+impl From<QueryChannelRequest> for RawQueryChannelRequest {
+    fn from(request: QueryChannelRequest) -> Self {
+        Self {
+            port_id: request.port_id.to_string(),
+            channel_id: request.channel_id.to_string(),
+        }
+    }
 }
 
 /// gRPC request to fetch the client state associated with a specified channel.


### PR DESCRIPTION
This PR:
- makes the `PenumbraChain` provider rely on IBC gRPC to query
- inserts a `height` field in the gRPC headers that serves as a query hint for the full node to generate proofs against a specific state root
- adds conversion traits between proto and domain types modeling the IBC RPC protocol 